### PR TITLE
Update - add support for Gnome Shell 3.26

### DIFF
--- a/maximus-three@daman.4880.gmail.com/app_menu.js
+++ b/maximus-three@daman.4880.gmail.com/app_menu.js
@@ -214,9 +214,6 @@ function enable() {
 
 	focusCallbackID = Shell.WindowTracker.get_default().connect('notify::focus-app', onFocusChange);
 
-	wmCallbackIDs.push(global.window_manager.connect('maximize', updateAppMenu));
-	wmCallbackIDs.push(global.window_manager.connect('unmaximize', updateAppMenu));
-
 	// note: 'destroy' needs a delay for .list_windows() report correctly
 	wmCallbackIDs.push(global.window_manager.connect('destroy', function () {
 		Mainloop.idle_add(updateAppMenu);

--- a/maximus-three@daman.4880.gmail.com/decoration.js
+++ b/maximus-three@daman.4880.gmail.com/decoration.js
@@ -312,9 +312,9 @@ function disable() {
 	workspaces = [];
 
 	let winList = global.get_window_actors().map(function (w) { return w.meta_window; }),
-		i       = winList.length;
-	while (i--) {
-		let win = winList[i];
+		j       = winList.length;
+	while (j--) {
+		let win = winList[j];
 		if (win.window_type === Meta.WindowType.DESKTOP) {
 			continue;
 		}


### PR DESCRIPTION
These were a few (lazy) fixes I made to make the extension work on Gnome Shell 3.26